### PR TITLE
regen now works off tick time

### DIFF
--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Alchemist.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Alchemist.java
@@ -27,7 +27,7 @@ public class MM_Alchemist extends MobModifier
     @Override
     public boolean onUpdate(EntityLivingBase mob)
     {
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse)
         {
             nextAbilityUse = time+coolDown;
@@ -72,7 +72,7 @@ public class MM_Alchemist extends MobModifier
     
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Alchemist.class.getSimpleName(), "coolDownMillis", 6000L, "Time between ability uses").getInt(6000);
+        coolDown = config.get(MM_Alchemist.class.getSimpleName(), "coolDownMillis", 6000L, "Time between ability uses").getInt(6000) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Blastoff.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Blastoff.java
@@ -59,7 +59,7 @@ public class MM_Blastoff extends MobModifier
             return;
         }
         
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse)
         {
             nextAbilityUse = time+coolDown;
@@ -78,7 +78,7 @@ public class MM_Blastoff extends MobModifier
     
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Blastoff.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000);
+        coolDown = config.get(MM_Blastoff.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Cloaking.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Cloaking.java
@@ -52,7 +52,7 @@ public class MM_Cloaking extends MobModifier
 
     private void tryAbility(EntityLivingBase mob)
     {
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse)
         {
             nextAbilityUse = time+coolDown;
@@ -63,7 +63,7 @@ public class MM_Cloaking extends MobModifier
     public static void loadConfig(Configuration config)
     {
         potionDuration = config.get(MM_Cloaking.class.getSimpleName(), "cloakingDurationTicks", 200L, "Time mob is cloaked").getInt(200);
-        coolDown = config.get(MM_Cloaking.class.getSimpleName(), "coolDownMillis", 12000L, "Time between ability uses").getInt(12000);
+        coolDown = config.get(MM_Cloaking.class.getSimpleName(), "coolDownMillis", 12000L, "Time between ability uses").getInt(12000) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ender.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ender.java
@@ -32,7 +32,7 @@ public class MM_Ender extends MobModifier
     @Override
     public float onHurt(EntityLivingBase mob, DamageSource source, float damage)
     {
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse && source.getEntity() != null && source.getEntity() != mob && teleportToEntity(mob, source.getEntity()) && !InfernalMobsCore.instance().isInfiniteLoop(mob, source.getEntity()))
         {
             nextAbilityUse = time + coolDown;
@@ -131,7 +131,7 @@ public class MM_Ender extends MobModifier
 
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Ender.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000);
+        coolDown = config.get(MM_Ender.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000) / 50;
         reflectMultiplier = (float) config.get(MM_Ender.class.getSimpleName(), "enderReflectMultiplier", 0.75D, "When a mob with Ender modifier gets hurt it teleports and reflects some of the damage originally dealt. This sets the multiplier for the reflected damage").getDouble(0.75D);
         maxReflectDamage = (float) config.get(MM_Ender.class.getSimpleName(), "enderReflectMaxDamage", 10.0D, "When a mob with Ender modifier gets hurt it teleports and reflects some of the damage originally dealt. This sets the maximum amount that can be inflicted (0, or less than zero for unlimited reflect damage)").getDouble(10.0D);
     }

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ghastly.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ghastly.java
@@ -27,7 +27,7 @@ public class MM_Ghastly extends MobModifier
     @Override
     public boolean onUpdate(EntityLivingBase mob)
     {
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse)
         {
             nextAbilityUse = time+coolDown;
@@ -63,7 +63,7 @@ public class MM_Ghastly extends MobModifier
 
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Ghastly.class.getSimpleName(), "coolDownMillis", 6000L, "Time between ability uses").getInt(6000);
+        coolDown = config.get(MM_Ghastly.class.getSimpleName(), "coolDownMillis", 6000L, "Time between ability uses").getInt(6000) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Gravity.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Gravity.java
@@ -60,7 +60,7 @@ public class MM_Gravity extends MobModifier
             return;
         }
         
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse)
         {
             nextAbilityUse = time+coolDown;
@@ -105,7 +105,7 @@ public class MM_Gravity extends MobModifier
 
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Gravity.class.getSimpleName(), "coolDownMillis", 5000L, "Time between ability uses").getInt(5000);
+        coolDown = config.get(MM_Gravity.class.getSimpleName(), "coolDownMillis", 5000L, "Time between ability uses").getInt(5000) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ninja.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ninja.java
@@ -32,7 +32,7 @@ public class MM_Ninja extends MobModifier
     @Override
     public float onHurt(EntityLivingBase mob, DamageSource source, float damage)
     {
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse
         && source.getEntity() != null
         && source.getEntity() != mob
@@ -119,7 +119,7 @@ public class MM_Ninja extends MobModifier
 
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Ninja.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000);
+        coolDown = config.get(MM_Ninja.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000) / 50;
         reflectMultiplier = (float) config.get(MM_Ninja.class.getSimpleName(), "ninjaReflectMultiplier", 0.75D, "When a mob with Ninja modifier gets hurt it teleports to the attacker and reflects some of the damage originally dealt. This sets the multiplier for the reflected damage").getDouble(0.75D);
         maxReflectDamage = (float) config.get(MM_Ninja.class.getSimpleName(), "ninjaReflectMaxDamage", 10.0D, "When a mob with Ninja modifier gets hurt it teleports to the attacker and reflects some of the damage originally dealt. This sets the maximum amount that can be inflicted (0, or less than zero for unlimited reflect damage)").getDouble(10.0D);
     }

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Regen.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Regen.java
@@ -26,7 +26,7 @@ public class MM_Regen extends MobModifier
     {
         if (mob.getHealth() < getActualMaxHealth(mob))
         {
-            long time = System.currentTimeMillis();
+            long time = mob.ticksExisted;
             if (time > nextAbilityUse)
             {
                 nextAbilityUse = time+coolDown;
@@ -38,7 +38,7 @@ public class MM_Regen extends MobModifier
 
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Regen.class.getSimpleName(), "coolDownMillis", 500L, "Time between ability uses").getInt(500);
+        coolDown = config.get(MM_Regen.class.getSimpleName(), "coolDownMillis", 500L, "Time between ability uses").getInt(500) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Sprint.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Sprint.java
@@ -26,7 +26,7 @@ public class MM_Sprint extends MobModifier
     {
         if (getMobTarget() != null)
         {
-            long time = System.currentTimeMillis();
+            long time = mob.ticksExisted;
             if (time > nextAbilityUse)
             {
                 nextAbilityUse = time+coolDown;
@@ -102,7 +102,7 @@ public class MM_Sprint extends MobModifier
     
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Sprint.class.getSimpleName(), "coolDownMillis", 5000L, "Time between ability uses").getInt(5000);
+        coolDown = config.get(MM_Sprint.class.getSimpleName(), "coolDownMillis", 5000L, "Time between ability uses").getInt(5000) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Sticky.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Sticky.java
@@ -39,7 +39,7 @@ public class MM_Sticky extends MobModifier
             ItemStack weapon = p.inventory.getStackInSlot(p.inventory.currentItem);
             if (weapon != null)
             {
-                long time = System.currentTimeMillis();
+                long time = mob.ticksExisted;
                 if (time > nextAbilityUse
                 && source.getEntity() != null
                 && !(source instanceof EntityDamageSourceIndirect))
@@ -60,7 +60,7 @@ public class MM_Sticky extends MobModifier
 
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Sticky.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000);
+        coolDown = config.get(MM_Sticky.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000) / 50;
     }
 
     private Class<?>[] disallowed = { EntityCreeper.class };

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Storm.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Storm.java
@@ -43,7 +43,7 @@ public class MM_Storm extends MobModifier
             return;
         }
         
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > nextAbilityUse
         && mob.getDistanceToEntity(target) > MIN_DISTANCE
         && target.worldObj.canBlockSeeTheSky(MathHelper.floor_double(target.posX), MathHelper.floor_double(target.posY), MathHelper.floor_double(target.posZ)))
@@ -55,7 +55,7 @@ public class MM_Storm extends MobModifier
 
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Storm.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000);
+        coolDown = config.get(MM_Storm.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000) / 50;
     }
 
     @Override

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Webber.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Webber.java
@@ -59,7 +59,7 @@ public class MM_Webber extends MobModifier
         int y = MathHelper.floor_double(target.posY);
         int z = MathHelper.floor_double(target.posZ);
         
-        long time = System.currentTimeMillis();
+        long time = mob.ticksExisted;
         if (time > lastAbilityUse+coolDown)
         {
             int offset;
@@ -84,7 +84,7 @@ public class MM_Webber extends MobModifier
     
     public static void loadConfig(Configuration config)
     {
-        coolDown = config.get(MM_Webber.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000);
+        coolDown = config.get(MM_Webber.class.getSimpleName(), "coolDownMillis", 15000L, "Time between ability uses").getInt(15000) / 50;
     }
 
     @Override


### PR DESCRIPTION
The unkillable mob situation was caused by these in combination
-Diamond spikes deal the exact amount of damage to kill.
-Bulwark directly reduces damage dealt by 1/2
-Regen worked by getting system time, which meant when the server was lagging, the regen would not slow down.

This change makes regen happen according to tick time rather than system time, which means the regen will never outpace the damage. The spike still only deals 1/2 of lethal damage each hit to bulwark mobs, but I can't see a way to fix that since Extra Utilities code can't be modified.

Also, most other infernal modifiers are also calling System.currentTimeMillis() every tick, is this possibly a lag source? I've only changed regen for this, but I could change all the others too if that is wanted.