### PR TITLE
Limit vengeance reflection to mob's current health

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614-1.7.10
-mod.version=1.7.2-GTNH
+mod.version=1.7.3-GTNH

--- a/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Vengeance.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Vengeance.java
@@ -24,15 +24,12 @@ public class MM_Vengeance extends MobModifier
     {
         if (source.getEntity() != null && source.getEntity() != mob && !InfernalMobsCore.instance().isInfiniteLoop(mob, source.getEntity()))
         {
-            if (maxReflectDamage <= 0.0f)
+            float reflectedDamage = Math.min(mob.getHealth(), Math.max(damage * reflectMultiplier, 1));
+            if (maxReflectDamage > 0.0f)
             {
-                source.getEntity().attackEntityFrom(DamageSource.causeMobDamage(mob), Math.max(damage * reflectMultiplier, 1));
+                reflectedDamage = Math.min(maxReflectDamage, reflectedDamage);
             }
-            else
-            {
-                source.getEntity().attackEntityFrom(DamageSource.causeMobDamage(mob),
-                        Math.min(maxReflectDamage, Math.max(damage * reflectMultiplier, 1)));
-            }
+            source.getEntity().attackEntityFrom(DamageSource.causeMobDamage(mob), reflectedDamage);
         }
 
         return super.onHurt(mob, source, damage);


### PR DESCRIPTION
I still feel like vengeance is an outlier in infernal mob modifiers. This PR nerfs them by capping the damage that they reflect to the mob's current health. This will prevent the player from taking additional damage due to overkilling a mob: the total damage taken should now roughly be the same regardless of the quality of the player's weapon.

For additional context, I originally explained my reasoning in this comment:
 * https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8238#issuecomment-881960610