### PR TITLE
Fix rendering mob particles from mods in other dimensions

### DIFF
--- a/src/main/java/atomicstryker/infernalmobs/client/RendererBossGlow.java
+++ b/src/main/java/atomicstryker/infernalmobs/client/RendererBossGlow.java
@@ -42,7 +42,8 @@ public class RendererBossGlow {
 
         Map<EntityLivingBase, MobModifier> mobsmap = InfernalMobsCore.proxy.getRareMobs();
         for (EntityLivingBase ent : mobsmap.keySet()) {
-            if (ent.isInRangeToRenderDist(curPos.distanceTo(ent.getPosition(1.0f)))
+            if (viewEnt.worldObj.provider.dimensionId == ent.worldObj.provider.dimensionId
+                    && ent.isInRangeToRenderDist(curPos.distanceTo(ent.getPosition(1.0f)))
                     && (ent.ignoreFrustumCheck || f.isBoundingBoxInFrustum(ent.boundingBox))
                     && ent.isEntityAlive()) {
                 mc.renderGlobal.spawnParticle(


### PR DESCRIPTION
This is a quick fix but the bug is more profound that that, it's that the server and client entities are mixed together and the client / server proxy aren't properly separeted from each other in this mod

![image](https://github.com/user-attachments/assets/add32b2a-b6df-46bd-b823-c43eeeaa1cf7)
