### PR TITLE
Move mob name above healthbar and adjust name colors

### DIFF
--- a/src/main/java/atomicstryker/infernalmobs/client/InfernalMobsClient.java
+++ b/src/main/java/atomicstryker/infernalmobs/client/InfernalMobsClient.java
@@ -132,15 +132,17 @@ public class InfernalMobsClient implements ISidedProxy {
                     * (float) (lifeBarLength + 1));
                 byte y = 12;
                 gui.drawTexturedModalRect(x, y, 0, 74, lifeBarLength, 5);
-                gui.drawTexturedModalRect(x, y, 0, 74, lifeBarLength, 5);
 
                 if (lifeBarLeft > 0) {
                     gui.drawTexturedModalRect(x, y, 0, 79, lifeBarLeft, 5);
                 }
 
-                int yCoord = 10;
+                int yCoord = 1;
                 fontR
                     .drawStringWithShadow(buffer, screenwidth / 2 - fontR.getStringWidth(buffer) / 2, yCoord, 0x2F96EB);
+
+                // spacing for healthbar
+                yCoord += 8;
 
                 String[] display = mod.getDisplayNames();
                 int i = 0;

--- a/src/main/java/atomicstryker/infernalmobs/common/modifiers/MobModifier.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/modifiers/MobModifier.java
@@ -420,8 +420,7 @@ public abstract class MobModifier {
                 ? EnumChatFormatting.YELLOW + StatCollector.translateToLocal("translation.infernalmobs:rareClass")
                 : size <= 10
                     ? EnumChatFormatting.GOLD + StatCollector.translateToLocal("translation.infernalmobs:ultraClass")
-                    : EnumChatFormatting.RED
-                        + StatCollector.translateToLocal("translation.infernalmobs:infernalClass");
+                    : EnumChatFormatting.RED + StatCollector.translateToLocal("translation.infernalmobs:infernalClass");
 
             buffer = prefix + modprefix + buffer;
 

--- a/src/main/java/atomicstryker/infernalmobs/common/modifiers/MobModifier.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/modifiers/MobModifier.java
@@ -417,10 +417,10 @@ public abstract class MobModifier {
             }
 
             String prefix = size <= 5
-                ? EnumChatFormatting.AQUA + StatCollector.translateToLocal("translation.infernalmobs:rareClass")
+                ? EnumChatFormatting.YELLOW + StatCollector.translateToLocal("translation.infernalmobs:rareClass")
                 : size <= 10
-                    ? EnumChatFormatting.YELLOW + StatCollector.translateToLocal("translation.infernalmobs:ultraClass")
-                    : EnumChatFormatting.GOLD
+                    ? EnumChatFormatting.GOLD + StatCollector.translateToLocal("translation.infernalmobs:ultraClass")
+                    : EnumChatFormatting.RED
                         + StatCollector.translateToLocal("translation.infernalmobs:infernalClass");
 
             buffer = prefix + modprefix + buffer;


### PR DESCRIPTION
This was requested in https://github.com/GTNewHorizons/Infernal-Mobs/pull/17#issuecomment-2500630739

After moving the mob name above the healthbar, I noticed that the default aqua color was a bit hard to read against the blue sky so I adjusted the colors:

Before: aqua (rare) -> yellow (ultra) -> gold (infernal)
After: yellow (rare) -> gold (ultra) -> red (infernal)

![2024-11-26_18 25 33](https://github.com/user-attachments/assets/b861f19a-0f9f-45f0-a8e4-57fefc639c1d)
![2024-11-26_18 25 44](https://github.com/user-attachments/assets/37eaf7b5-7403-4047-b922-d73eea7da1b1)
