### PR TITLE
Fix(MM_Choke): Properly checks for null before calling setAir on lastTarget

### DIFF
--- a/src/main/java/atomicstryker/infernalmobs/common/modifiers/MM_Choke.java
+++ b/src/main/java/atomicstryker/infernalmobs/common/modifiers/MM_Choke.java
@@ -47,7 +47,9 @@ public class MM_Choke extends MobModifier {
                         lastTarget.attackEntityFrom(DamageSource.drown, 2.0F);
                     }
 
-                    updateAir();
+                    if (!mob.isDead) {
+                        updateAir();
+                    }
                 }
             }
         }
@@ -76,6 +78,8 @@ public class MM_Choke extends MobModifier {
     }
 
     private void updateAir() {
+        if (lastTarget == null) return;
+
         lastTarget.setAir(lastAir);
         if (lastTarget instanceof EntityPlayerMP) {
             InfernalMobsCore.instance()


### PR DESCRIPTION
When the mob is applying to the player the drowning damage, and the player somehow has a way to reflect the damage to the mob and kills it, the mob will die and set `lastTarget` as null. That's the only possible situation in which I can think this crash can happen, but i did not manage to reproduce it, as thorns does not apply.

Also added a check for mob is dead to avoid triggering updateAir twice.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#18374